### PR TITLE
Switch to softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,43 +38,17 @@ jobs:
         zip -r ../elcap-deps-macos-${{ steps.vars.outputs.short_sha }}.zip .
         cd ..
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create and upload release
+      uses: softprops/action-gh-release@v2.3.2
       with:
         tag_name: release-${{ steps.vars.outputs.short_sha }}
-        release_name: elcap-deps-${{ steps.vars.outputs.short_sha }}
+        name: elcap-deps-${{ steps.vars.outputs.short_sha }}
         draft: false
         prerelease: false
-
-    - name: Upload Windows Release Asset
-      uses: actions/upload-release-asset@v1
+        files: |
+          ./elcap-deps-windows-${{ steps.vars.outputs.short_sha }}.zip
+          ./elcap-deps-linux-${{ steps.vars.outputs.short_sha }}.tar.gz
+          ./elcap-deps-macos-${{ steps.vars.outputs.short_sha }}.zip
+        fail_on_unmatched_files: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./elcap-deps-windows-${{ steps.vars.outputs.short_sha }}.zip
-        asset_name: elcap-deps-windows-${{ steps.vars.outputs.short_sha }}.zip
-        asset_content_type: application/zip
-
-    - name: Upload Linux Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./elcap-deps-linux-${{ steps.vars.outputs.short_sha }}.tar.gz
-        asset_name: elcap-deps-linux-${{ steps.vars.outputs.short_sha }}.tar.gz
-        asset_content_type: application/gzip
-
-    - name: Upload MacOS Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./elcap-deps-macos-${{ steps.vars.outputs.short_sha }}.zip
-        asset_name: elcap-deps-macos-${{ steps.vars.outputs.short_sha }}.zip
-        asset_content_type: application/zip


### PR DESCRIPTION
actions/create-release has been deprecated due to vulnerabilities. Switching to softprops allows the handling of creation and upload in one action. This is what we use on the elcap side for the same thing.

Tested by kicking off a new workflow. No warnings and the files upload as expected.

closes tridentiot/elcap-cli#743